### PR TITLE
Feature/import file

### DIFF
--- a/MarkdownEditor/MarkdownEditor/ContentView.swift
+++ b/MarkdownEditor/MarkdownEditor/ContentView.swift
@@ -8,14 +8,11 @@
 import SwiftUI
 
 struct ContentView: View {
-    let fileVM = FileViewModel.shared
-    @State private var textString: String = ""
+    @ObservedObject var fileVM = FileViewModel.shared
+    @State private var document: ReadMeDocument = ReadMeDocument(text: "")
     
     var body: some View {
-        TextEditor(text: $textString)
-            .onChange(of: textString) {
-                fileVM.textString = self.textString
-            }
+        TextEditor(text: $fileVM.textString)
     }
 }
 

--- a/MarkdownEditor/MarkdownEditor/MarkdownEditorApp.swift
+++ b/MarkdownEditor/MarkdownEditor/MarkdownEditorApp.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct MarkdownEditorApp: App {
     @State private var saveBool = false
     @State private var saveAsBool = false
+    @State private var openBool = false
     @State private var showType = 0 // 0 : EditorOnly , 1 : editor & preview, 2: PreviewOnly
     @State private var document: ReadMeDocument?
     
@@ -35,7 +36,7 @@ struct MarkdownEditorApp: App {
                     document = ReadMeDocument(text: fileVM.textString)
                     saveBool.toggle()
                 }
-//                .keyboardShortcut("s")
+                //                .keyboardShortcut("s")
                 .fileExporter(isPresented: $saveBool,
                               document: document,
                               contentType: .md,
@@ -48,7 +49,25 @@ struct MarkdownEditorApp: App {
                         print(error)
                     }
                 }
+                .keyboardShortcut(KeyEquivalent("s"), modifiers: .command)
                 
+                Button("Open") {
+                    openBool.toggle()
+                }
+                .fileImporter(isPresented: $openBool,
+                              allowedContentTypes: [.plainText])
+                { result in
+                    switch result {
+                    case .success(let file):
+                        guard let url = URL(string: file.absoluteString) else {
+                            print("there's no file")
+                            return
+                        }
+                        loadFileContent(from: url)
+                    case .failure(let error):
+                        print(error.localizedDescription)
+                    }
+                }
                 //                    .fileImporter(isPresented: $saveBool, allowedContentTypes: [.folder]) { result in
                 //                        switch result {
                 //                        case .success(let url) :
@@ -60,20 +79,17 @@ struct MarkdownEditorApp: App {
                 //
                 //                        }
                 //                    }
-                
-                .keyboardShortcut(KeyEquivalent("s"), modifiers: .command)
-                
-                Button("Save As") { saveAsBool.toggle() }
-                    .fileImporter(isPresented: $saveAsBool, allowedContentTypes: [.folder]) { result in
-                        switch result {
-                        case .success(let url) :
-                            print("success: ",url)
-                        case .failure(let error) :
-                            print("fail: ",error)
-                            
-                        }
-                    }
-                    .keyboardShortcut(KeyEquivalent("s"), modifiers: .command.union(.shift))
+                //                Button("Save As") { saveAsBool.toggle() }
+                //                    .fileImporter(isPresented: $saveAsBool, allowedContentTypes: [.folder]) { result in
+                //                        switch result {
+                //                        case .success(let url) :
+                //                            print("success: ",url)
+                //                        case .failure(let error) :
+                //                            print("fail: ",error)
+                //
+                //                        }
+                //                    }
+                //                    .keyboardShortcut(KeyEquivalent("s"), modifiers: .command.union(.shift))
             }
             
             CommandGroup(after: .sidebar) {
@@ -85,7 +101,6 @@ struct MarkdownEditorApp: App {
                     Button("Editor & Preview") {
                         
                     }
-//                    .keyboardShortcut(KeyEquivalent("s"), modifiers: .command)
                     Button("Preview Only") {
                         
                     }
@@ -95,6 +110,20 @@ struct MarkdownEditorApp: App {
             }
         }
         
+    }
+    
+    func loadFileContent(from url: URL) {
+        do {
+            // 파일 URL에서 텍스트 읽기
+            guard url.startAccessingSecurityScopedResource() else { return }
+            let text = try String(contentsOf: url)
+            fileVM.textString = text // 읽은 내용을 상태 변수에 저장
+            print(fileVM.textString)
+            url.stopAccessingSecurityScopedResource()
+        } catch {
+            print("파일 읽기 오류: \(error)")
+            fileVM.textString = "파일을 읽을 수 없습니다."
+        }
     }
     
 }

--- a/MarkdownEditor/MarkdownEditor/MarkdownEditorApp.swift
+++ b/MarkdownEditor/MarkdownEditor/MarkdownEditorApp.swift
@@ -68,6 +68,7 @@ struct MarkdownEditorApp: App {
                         print(error.localizedDescription)
                     }
                 }
+                .keyboardShortcut(KeyEquivalent("o"), modifiers: .command)
                 //                    .fileImporter(isPresented: $saveBool, allowedContentTypes: [.folder]) { result in
                 //                        switch result {
                 //                        case .success(let url) :


### PR DESCRIPTION
## 요약

파일 불러오기 구현 완료

## 자세한 설명

파일 불러오기 기능을 MarkdownEditorApp.swift 파일에 CommandGroup과 함께 추가했고
기존에는 ContentView에 텍스트 변수를 FileViewModel 의 텍스트 변수와 연결해서 저장하였으나
파일을 불러올때 정상적으로 반영되지 않아 FileViewModel의 textString을 직접적으로 바인딩 해
ContentView의 불필요한 변수 제거 및 바인딩을 통한 즉각적으로 뷰에 반영하도록함

## PR타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 추가 / 수정
- [ ] 기타 : 내용 추가 바람.